### PR TITLE
Update team points after game persistence with a dedicated service

### DIFF
--- a/src/Controller/TeamController.php
+++ b/src/Controller/TeamController.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Security\Http\Attribute\IsGranted;

--- a/src/DataFixtures/GameFixtures.php
+++ b/src/DataFixtures/GameFixtures.php
@@ -2,10 +2,10 @@
 
 namespace App\DataFixtures;
 
-use Faker\Factory;
+
 use App\Entity\Game;
-use Faker\Generator;
 use DateTimeImmutable;
+use App\Service\TeamService;
 use App\DataFixtures\TeamFixtures;
 use Doctrine\Persistence\ObjectManager;
 use App\DataFixtures\AbstractBasicFixtures;
@@ -15,8 +15,9 @@ class GameFixtures extends AbstractBasicFixtures implements DependentFixtureInte
 {
     private const GAMES_COUNT = 100;
 
-    public function __construct()
-    {
+    public function __construct(
+        private TeamService $teamService
+    ){
         parent::__construct();
     }
 
@@ -36,7 +37,11 @@ class GameFixtures extends AbstractBasicFixtures implements DependentFixtureInte
             $this->addReference('game_' . $i, $game);
         }
 
+
+
         $manager->flush();
+
+
     }
 
     public function getDependencies(): array

--- a/src/DataFixtures/TeamFixtures.php
+++ b/src/DataFixtures/TeamFixtures.php
@@ -20,7 +20,6 @@ class TeamFixtures extends AbstractBasicFixtures
         for ($i = 0; $i < self::TEAMS_COUNT; $i++) {
             $team = new Team();
             $team->setName($this->faker->city);
-            $team->setPoints($this->faker->numberBetween(0, 100));
             $manager->persist($team);
 
             $this->addReference('team_' . $i, $team);

--- a/src/EventListener/GameListener.php
+++ b/src/EventListener/GameListener.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\EventListener;
+
+use App\Entity\Game;
+use App\Service\TeamService;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\ORM\Events;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
+
+#[AsDoctrineListener(event: Events::postPersist)]
+#[AsDoctrineListener(event: Events::postUpdate)]
+class GameListener
+{
+    public function __construct(
+        private TeamService $teamService
+    ) {}
+
+    public function postPersist(LifecycleEventArgs $args): void
+    {
+        $this->updatePoints($args);
+    }
+
+    public function postUpdate(LifecycleEventArgs $args): void
+    {
+        $this->updatePoints($args);
+    }
+
+    private function updatePoints(LifecycleEventArgs $args): void
+    {
+        $entity = $args->getObject();
+
+        if (!$entity instanceof Game) {
+            return;
+        }
+
+        $this->teamService->updateTeamPoints($entity);
+        $args->getObjectManager()->flush();
+    }
+}

--- a/src/Service/TeamService.php
+++ b/src/Service/TeamService.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Game;
+
+class TeamService
+{
+    private const POINTS_VICTORY = 3;
+    private const POINTS_DRAW = 1;
+
+    public function updateTeamPoints(Game $game): void
+    {
+        $homeTeam = $game->getHomeTeam();
+        $awayTeam = $game->getAwayTeam();
+
+        $homeScore = $game->getHomeScore();
+        $awayScore = $game->getAwayScore();
+
+        if ($homeScore > $awayScore) {
+            $homeTeam->setPoints($homeTeam->getPoints() + self::POINTS_VICTORY);
+        } elseif ($homeScore < $awayScore) {
+            $awayTeam->setPoints($awayTeam->getPoints() + self::POINTS_VICTORY);
+        } else {
+            $homeTeam->setPoints($homeTeam->getPoints() + self::POINTS_DRAW);
+            $awayTeam->setPoints($awayTeam->getPoints() + self::POINTS_DRAW);
+        }
+
+    }
+}


### PR DESCRIPTION
Adding the logic for updating team points after persisting and updating games, with the introduction of a dedicated service to manage points.